### PR TITLE
feat: add steering-list credential

### DIFF
--- a/credentials/2022-neo/neo-document-loader.ts
+++ b/credentials/2022-neo/neo-document-loader.ts
@@ -6,6 +6,7 @@ import energyLocationContext from './energy-location/energy-location-context.jso
 import energyStorageContext from './energy-storage/energy-storage-context.json'
 import meteringDeviceContext from './metering-device/metering-device-context.json'
 import productionContext from './production/production-context.json'
+import steeringListContext from './steering-list/steering-list-context.json'
 import { JsonLd, RemoteDocument } from 'jsonld/jsonld-spec'
 import { baseContextMap } from '../../test/document-loader'
 
@@ -17,6 +18,7 @@ const contextMap = Object.assign({
     'https://vc-context.elia.be/2022/v1/energy-storage': energyStorageContext,
     'https://vc-context.elia.be/2022/v1/metering-device': meteringDeviceContext,
     'https://vc-context.elia.be/2022/v1/production': productionContext,
+    'https://vc-context.elia.be/2022/v1/steering-list': steeringListContext,
 } , baseContextMap)
 
 const didDocMap: { [url: string]: JsonLd } = {

--- a/credentials/2022-neo/steering-list/steering-list-context.json
+++ b/credentials/2022-neo/steering-list/steering-list-context.json
@@ -3,15 +3,37 @@
     "@version": 1.1,
     "@protected": true,
     "elia": "https://vc-context.elia.be/2022/v1/",
-    "saref4ener": "https://saref.etsi.org/saref4ener/",
 
     "SteeringListCredential": "elia:SteeringListCredential",
-    "SteeringList": {
-      "@id": "elia:SteeringList",
+
+    "SteerableDevice": {
+      "@id": "elia:SteerableDevice",
       "@context": {
         "@version": 1.1,
         "@protected": true,
-        "connectivityStandards": "elia:connectivityStandards"
+        "hasCloudSteeringList": "elia:hasCloudSteeringList",
+        "hasLocalSteeringList": "elia:hasLocalSteeringList"
+      }
+    },
+
+    "CloudSteeringList": {
+      "@id": "elia:CloudSteeringList",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "documentationLink": "elia:documentationLink",
+        "documentationTags": "elia:documentationTags"
+      }
+    },
+
+    "LocalSteeringList": {
+      "@id": "elia:LocalSteeringList",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "documentationLink": "elia:documentationLink",
+        "communicationProtocol": "elia:communicationProtocol",
+        "communicationType": "elia:communicationType"
       }
     }
   }

--- a/credentials/2022-neo/steering-list/steering-list-credential.json
+++ b/credentials/2022-neo/steering-list/steering-list-credential.json
@@ -1,0 +1,28 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://vc-context.elia.be/2022/v1/steering-list"
+  ],
+  "type": [
+    "VerifiableCredential",
+    "SteeringListCredential"
+  ],
+  "id": "some URI, e.g. https://installer.example.com/credential/1",
+  "credentialSubject": {
+    "id": "deviceIdScheme:123",
+    "type": "SteerableDevice",
+    "hasCloudSteeringList": {
+      "type": "CloudSteeringList",
+      "documentationLink": "https://example.com/cloud",
+      "documentationTags": ["tag1", "tag2"]
+    },
+    "hasLocalSteeringList": {
+      "type": "LocalSteeringList",
+      "documentationLink": "https://example.com/local",
+      "communicationProtocol": "zigbee",
+      "communicationType": "modbus"
+    }
+  },
+  "issuer": "did:example:dso",
+  "issuanceDate": "2021-05-14T12:55:30Z"
+}

--- a/credentials/2022-neo/steering-list/steering-list.test.ts
+++ b/credentials/2022-neo/steering-list/steering-list.test.ts
@@ -1,0 +1,54 @@
+import { Options, compact } from 'jsonld'
+import credential from './steering-list-credential.json'
+import { issueAndVerify } from '../../../test/issue-and-verify'
+import { digitalBazaarDocumentLoader, transmuteDocumentLoader } from '../neo-document-loader'
+
+describe("Production ", () => {
+  // test("Credential should match JSON Schema", async () => {
+  //   verifyCredentialSubjectSchema(schema, credential)
+  // })
+
+  test("Credential can be issued and verified", async () => {
+    await issueAndVerify(credential, transmuteDocumentLoader)
+  })
+
+  test("Compacted credential is as expected", async () => {
+    const options: Options.Compact = {
+      documentLoader: digitalBazaarDocumentLoader
+    }
+    const compacted = await compact(credential, {}, options)
+    const expected = {
+      "@id": "some URI, e.g. https://installer.example.com/credential/1",
+      "@type": [
+        "https://www.w3.org/2018/credentials#VerifiableCredential",
+        "https://vc-context.elia.be/2022/v1/SteeringListCredential",
+      ],
+      "https://www.w3.org/2018/credentials#credentialSubject": {
+        "@id": "deviceIdScheme:123",
+        "@type": "https://vc-context.elia.be/2022/v1/SteerableDevice",
+        "https://vc-context.elia.be/2022/v1/hasCloudSteeringList": {
+          "@type": "https://vc-context.elia.be/2022/v1/CloudSteeringList",
+          "https://vc-context.elia.be/2022/v1/documentationLink": "https://example.com/cloud",
+          "https://vc-context.elia.be/2022/v1/documentationTags": [
+            "tag1",
+            "tag2",
+          ],
+        },
+        "https://vc-context.elia.be/2022/v1/hasLocalSteeringList": {
+          "@type": "https://vc-context.elia.be/2022/v1/LocalSteeringList",
+          "https://vc-context.elia.be/2022/v1/communicationProtocol": "zigbee",
+          "https://vc-context.elia.be/2022/v1/communicationType": "modbus",
+          "https://vc-context.elia.be/2022/v1/documentationLink": "https://example.com/local",
+        },
+      },
+      "https://www.w3.org/2018/credentials#issuanceDate": {
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+        "@value": "2021-05-14T12:55:30Z",
+      },
+      "https://www.w3.org/2018/credentials#issuer": {
+        "@id": "did:example:dso",
+      },
+    }
+    expect(compacted).toEqual(expected)
+  })
+})


### PR DESCRIPTION
Updates the `steering-list` context and credential based on the following description from Elia:

List for steering:
- Cloud steering 
  - Documentation link for real time communication 
  - Specific tags from documentation that applies to this device 
- Local steering 
  - Communication protocol 
    - Ethernet connection, zigbee, z-wave, ... 
  - Type of com? 
    - Modbus, MQTT, canbus, VE-bus 
  - Documentation link 